### PR TITLE
Docker tag main as latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Build Docker Image
         run: |
             tag=$(git describe --tags --abbrev=0)
-            echo $GITHUB_REF_NAME
             if [ $GITHUB_REF_NAME == "main" ]; then
                 docker build . -t "erzulie/mecon:$tag" -t "erzulie/mecon:latest" -f ./Build/Dockerfile
             else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
             tag=$(git describe --tags --abbrev=0)
             branch=$(git branch --show-current)
+            echo "branch:$branch"
             if [ "$branch" == "main" ]; then
                 docker build . -t "erzulie/mecon:$tag" -t "erzulie/mecon:latest" -f ./Build/Dockerfile
             else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,8 @@ jobs:
       - name: Build Docker Image
         run: |
             tag=$(git describe --tags --abbrev=0)
-            branch=$(git branch --show-current)
-            echo "branch:$branch"
-            if [ "$branch" == "main" ]; then
+            echo $GITHUB_REF_NAME
+            if [ $GITHUB_REF_NAME == "main" ]; then
                 docker build . -t "erzulie/mecon:$tag" -t "erzulie/mecon:latest" -f ./Build/Dockerfile
             else
                 docker build . -t "erzulie/mecon:$tag" -f ./Build/Dockerfile


### PR DESCRIPTION
`git branch --show-current` was not returning anything so the workflow was failing to tag as `latest`. The use of the GITHUB_REF_NAME environment variable instead fixes this.