### PR TITLE
Move to GitHub container repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push Docker Image
-        run: docker push --all-tags erzulie/mecon
+        run: docker push --all-tags ghcr.io/elzik/mecon
   binaries:
     name: Publish Binaries
     needs: container

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker Image
         run: docker push --all-tags ghcr.io/elzik/mecon
   binaries:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
             raw=$(git branch -r --contains ${{ github.ref }})
             branch=${raw##*/}
             echo "Branch:$branch"
-            docker build . -t "erzulie/mecon:$tag" -f ./Build/Dockerfile
+            docker build . -t "ghcr.io/elzik/mecon:$tag" -f ./Build/Dockerfile
             if [ $branch == "main" ]; then
             echo "Tagging with latest"
                 docker tag "erzulie/mecon:$tag" erzulie/mecon:latest

--- a/Build/Dockerfile
+++ b/Build/Dockerfile
@@ -12,5 +12,8 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 COPY Build/keep-alive.sh .
+LABEL org.opencontainers.image.source=https://github.com/elzik/mecon
+LABEL org.opencontainers.image.description="Find media that exists in Plex but needn't and media that you expect to be present but isn't"
+LABEL org.opencontainers.image.licenses=GPL-3.0
 ENV PATH /app:$PATH
 ENTRYPOINT ["/bin/bash", "keep-alive.sh"]

--- a/Install/Docker/docker-compose.yml
+++ b/Install/Docker/docker-compose.yml
@@ -5,4 +5,4 @@ services:
         environment:
             - Mecon__Plex__BaseUrl=http://<plex-server-host>:<plex-server-port>
             - Mecon__Plex__AuthToken=<plex-server-token>
-        image: erzulie/mecon
+        image: ghcr.io/elzik/mecon

--- a/Install/Docker/docker-compose.yml
+++ b/Install/Docker/docker-compose.yml
@@ -5,4 +5,4 @@ services:
         environment:
             - Mecon__Plex__BaseUrl=http://<plex-server-host>:<plex-server-port>
             - Mecon__Plex__AuthToken=<plex-server-token>
-        image: erzulie/mecon:latest
+        image: erzulie/mecon

--- a/README.md
+++ b/README.md
@@ -18,15 +18,11 @@
 
 ### Docker
 
-A Docker image is available from Docker Hub:
-``` sh
-docker pull erzulie/mecon
-```
-
-Once the image has been pulled, the container can be run and left running using either the Docker CLI or Docker Compose. Although everything can be passed in on the command line when running the `mecon` binary itself, using environment variables for at least your Plex host and token is useful:
+A Docker image is available from Docker Hub. Once the image has been pulled, the container can be run and left running using either the Docker CLI or Docker Compose. Although everything can be passed in on the command line when running the `mecon` binary itself, using environment variables for at least your Plex host and token is useful:
 
 #### Docker CLI
 ``` sh
+docker pull erzulie/mecon
 docker run -d --name mecon2 -e Mecon__Plex__BaseUrl=http://<plex-server-host>:<plex-server-port> -e Mecon__Plex__AuthToken=<plex-server-token> erzulie/mecon
 ```
 
@@ -39,7 +35,7 @@ services:
         environment:
             - Mecon__Plex__BaseUrl=http://<plex-server-host>:<plex-server-port>
             - Mecon__Plex__AuthToken=<plex-server-token>
-        image: erzulie/mecon:latest
+        image: erzulie/mecon
 ```
 
 #### Running mecon within the container

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Docker image is available from Docker Hub. Once the image has been pulled, the
 
 #### Docker CLI
 ``` sh
-docker pull erzulie/mecon
+docker pull ghcr.io/elzik/mecon
 docker run -d --name mecon2 -e Mecon__Plex__BaseUrl=http://<plex-server-host>:<plex-server-port> -e Mecon__Plex__AuthToken=<plex-server-token> erzulie/mecon
 ```
 


### PR DESCRIPTION
Publish Docker images to the GitHub container repository instead of DockerHub.